### PR TITLE
dynamic posts table

### DIFF
--- a/app/View/Editor.php
+++ b/app/View/Editor.php
@@ -183,7 +183,8 @@ class Editor {
 	 */
 	public function edit_screen_orderby( $orderby, $query ) {
 		if ( is_admin() && $query->query_vars['post_type'] === 'gistpen' ) {
-			$orderby = 'wp_posts.post_date DESC';
+			global $wpdb;
+			$orderby = $wpdb->posts . '.post_date DESC';
 		}
 
 		return $orderby;


### PR DESCRIPTION
use posts table name from $wpdb rather than hardcoding it to avoid
issues with MultiSite WP installs

On Multisite installations the Gistpen overview wouldn't load due to a MySQL error.