### PR TITLE
Add support for serving raw like GitHub

### DIFF
--- a/app/Http/BlobController.php
+++ b/app/Http/BlobController.php
@@ -1,0 +1,109 @@
+<?php
+namespace Intraxia\Gistpen\Http;
+
+use Intraxia\Gistpen\Database\EntityManager;
+use Intraxia\Gistpen\Model\Blob;
+use Intraxia\Gistpen\Model\Repo;
+use Intraxia\Jaxion\Contract\Core\HasFilters;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class BlobController
+ *
+ * @package    Intraxia\Gistpen
+ * @subpackage Http
+ */
+class BlobController implements HasFilters {
+	/**
+	 * Database interface service.
+	 *
+	 * @var EntityManager
+	 */
+	protected $em;
+
+	/**
+	 * RepoController constructor.
+	 *
+	 * @param EntityManager $database
+	 */
+	public function __construct( EntityManager $em ) {
+		$this->em = $em;
+	}
+
+	/**
+	 * Fetches the requested Blob and sets up the appropriate response.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function raw( WP_REST_Request $request ) {
+		/** @var Repo|WP_Error $repo */
+		$repo = $this->em->find( EntityManager::REPO_CLASS, $request->get_param( 'repo_id' ) );
+
+		if ( is_wp_error( $repo ) ) {
+			$repo->add_data( array( 'status' => 404 ) );
+
+			return $repo;
+		}
+
+		/** @var Blob|null $blob */
+		$blob = $repo->blobs->find(function( $blob ) use ( $request ) {
+			if ( (string) $blob->ID === (string) $request->get_param( 'blob_id' ) ) {
+				return true;
+			}
+
+			return false;
+		});
+
+		if ( ! $blob ) {
+			return new WP_Error( 'invalid_blob_id', __( 'Invalid Blob ID', 'wp-gistpen' ), array( 'status' => 404 ) );
+		}
+
+		$response = new WP_REST_Response( $blob->code, 200 );
+		$response->header( 'Content-Type', 'text/plain; charset=utf-8' );
+		$response->header( 'Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'" );
+
+		return $response;
+	}
+
+	/**
+	 * Overwrites the default API server response when serving raw,
+	 * ensuring the response isn't JSON encoded and echoed directly.
+	 *
+	 * @param boolean          $served
+	 * @param WP_REST_Response $response
+	 * @param WP_REST_Request  $request
+	 *
+	 * @return bool
+	 */
+	public function serve_raw( $served, WP_REST_Response $response, WP_REST_Request $request ) {
+		if ( $served ||
+			$request->get_method() !== 'GET' ||
+			! preg_match('/\/intraxia\/v1\/gistpen\/repos\/\d+\/blobs\/\d+\/raw/', $request->get_route() )
+		) {
+			return $served;
+		}
+
+		echo $response->get_data();
+
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array[]
+	 */
+	public function filter_hooks() {
+		return array(
+			array(
+				'hook'   => 'rest_pre_serve_request',
+				'method' => 'serve_raw',
+				'args'   => 3,
+			)
+		);
+	}
+}

--- a/app/Model/Blob.php
+++ b/app/Model/Blob.php
@@ -126,10 +126,9 @@ class Blob extends Model implements UsesWordPressPost {
 	 */
 	protected function compute_raw_url() {
 		return rest_url( sprintf(
-			'intraxia/v1/gistpen/repos/%s/%s/%s',
+			'intraxia/v1/gistpen/repos/%s/blobs/%s/raw',
 			$this->repo_id,
-			$this->ID,
-			$this->filename
+			$this->ID
 		) );
 	}
 

--- a/app/Providers/ControllerServiceProvider.php
+++ b/app/Providers/ControllerServiceProvider.php
@@ -5,8 +5,8 @@ use Intraxia\Gistpen\Http\JobController;
 use Intraxia\Gistpen\Http\SearchController;
 use Intraxia\Gistpen\Http\SiteController;
 use Intraxia\Gistpen\Http\UserController;
-use Intraxia\Gistpen\Http\ZipController;
 use Intraxia\Gistpen\Http\RepoController;
+use Intraxia\Gistpen\Http\BlobController;
 use Intraxia\Jaxion\Contract\Core\Container;
 use Intraxia\Jaxion\Contract\Core\ServiceProvider;
 
@@ -42,5 +42,9 @@ class ControllerServiceProvider implements ServiceProvider {
 		$container->share( array( 'controller.repo' => 'Intraxia\Gistpen\Http\RepoController' ), function ( $app ) {
 			return new RepoController( $app->fetch( 'database' ) );
 		} );
+		$container->share( array( 'controller.blob' => 'Intraxia\Gistpen\Http\BlobController' ), function ( $app ) {
+			return new BlobController( $app->fetch( 'database' ) );
+		} );
+
 	}
 }

--- a/app/Providers/RouterServiceProvider.php
+++ b/app/Providers/RouterServiceProvider.php
@@ -26,6 +26,7 @@ class RouterServiceProvider extends ServiceProvider {
 			'user'   => $this->container->fetch( 'controller.user' ),
 			'job'    => $this->container->fetch( 'controller.job' ),
 			'repo'   => $this->container->fetch( 'controller.repo' ),
+			'blob'   => $this->container->fetch( 'controller.blob' ),
 			'site'   => $this->container->fetch( 'controller.site' ),
 		);
 
@@ -55,6 +56,11 @@ class RouterServiceProvider extends ServiceProvider {
 //				'filter' => new RepoFilter,
 				'guard'  => new Guard( array( 'rule' => 'can_edit_others_posts' ) ),
 			) );
+
+			/**
+			 * /repos/{repo_id}/blobs/{blob_id} endpoints
+			 */
+			$router->get( '/repos/(?P<repo_id>\d+)/blobs/(?P<blob_id>\d+)/raw', array( $controllers['blob'], 'raw' ) );
 
 			/**
 			 * /search endpoint

--- a/composer.lock
+++ b/composer.lock
@@ -109,12 +109,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/intraxia/jaxion.git",
-                "reference": "7bf0c1d0cc55387d6c4a26ba29062bf997626a2f"
+                "reference": "ad6802b49af2662f8b2f65b4cf522910cc81d6aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/intraxia/jaxion/zipball/7bf0c1d0cc55387d6c4a26ba29062bf997626a2f",
-                "reference": "7bf0c1d0cc55387d6c4a26ba29062bf997626a2f",
+                "url": "https://api.github.com/repos/intraxia/jaxion/zipball/ad6802b49af2662f8b2f65b4cf522910cc81d6aa",
+                "reference": "ad6802b49af2662f8b2f65b4cf522910cc81d6aa",
                 "shasum": ""
             },
             "require": {
@@ -144,7 +144,7 @@
                 }
             ],
             "description": "A WordPress plugin framework for modern WordPress development.",
-            "time": "2016-12-19 00:03:37"
+            "time": "2016-12-19 12:51:54"
         },
         {
             "name": "knplabs/github-api",

--- a/test/unit/Model/BlobTest.php
+++ b/test/unit/Model/BlobTest.php
@@ -45,10 +45,9 @@ class BlobTest extends TestCase {
 		$this->assertSame( strlen( $this->blob->post_content ), $blob->size );
 		$this->assertSame( $this->repo->ID, $blob->repo_id );
 		$this->assertSame( rest_url( sprintf(
-			'intraxia/v1/gistpen/repos/%s/%s/%s',
+			'intraxia/v1/gistpen/repos/%s/blobs/%s/raw',
 			$this->repo->ID,
-			$this->blob->ID,
-			$blob->filename
+			$this->blob->ID
 		) ), $blob->raw_url );
 
 		$json = $blob->serialize();


### PR DESCRIPTION
Adds a BlobController to serve the Blob raw to the user, settings the
proper `Content-Type` headers so the browser doesn't interpret the
content as plaintext. Also overwrites the process for serving the content
so the content doesn't get `json_encode`d.

Fixes #48.