### PR TITLE
Update Blobs to be queryable by repo_id

### DIFF
--- a/app/Database/Repository/WordPressPost.php
+++ b/app/Database/Repository/WordPressPost.php
@@ -6,6 +6,7 @@ use Exception;
 use Intraxia\Gistpen\Database\EntityManager;
 use Intraxia\Gistpen\Model\Blob;
 use Intraxia\Gistpen\Model\Commit;
+use Intraxia\Gistpen\Model\Klass;
 use Intraxia\Gistpen\Model\Language;
 use Intraxia\Gistpen\Model\Repo;
 use Intraxia\Gistpen\Model\State;
@@ -107,6 +108,10 @@ class WordPressPost extends AbstractRepository {
 		);
 
 		if ( $class === EntityManager::COMMIT_CLASS ) {
+			$query_args['post_parent'] = $params['repo_id'];
+		}
+
+		if ( $class === Klass::BLOB && isset( $params['repo_id'] ) ) {
 			$query_args['post_parent'] = $params['repo_id'];
 		}
 

--- a/test/unit/Database/EntityManager/PostAndTermTest.php
+++ b/test/unit/Database/EntityManager/PostAndTermTest.php
@@ -5,6 +5,7 @@ namespace Intraxia\Gistpen\Test\Database\EntityManager;
 use Intraxia\Gistpen\Database\EntityManager;
 use Intraxia\Gistpen\Model\Blob;
 use Intraxia\Gistpen\Model\Commit;
+use Intraxia\Gistpen\Model\Klass;
 use Intraxia\Gistpen\Model\Language;
 use Intraxia\Gistpen\Model\Repo;
 use Intraxia\Gistpen\Model\State;
@@ -98,6 +99,15 @@ class PostAndTermTest extends TestCase {
 		$blobs = $this->em->find_by( EntityManager::BLOB_CLASS );
 
 		$this->assertInstanceOf( 'Intraxia\Jaxion\Axolotl\Collection', $blobs );
+		$this->assertCount( 3, $blobs );
+	}
+
+	public function test_should_return_repos_by_repo_id() {
+		$this->create_post_and_children( false );
+		$blobs = $this->em->find_by( Klass::BLOB , array(
+			'repo_id' => $this->repo->ID,
+		) );
+
 		$this->assertCount( 3, $blobs );
 	}
 


### PR DESCRIPTION
Check and set into the query args when we have this. We do
have a lot of app-specific code in here, but we're still trying
to decide how we should abstract this stuff out.

Fixes #113.