### PR TITLE
Add basic support for order_by in CustomTable

### DIFF
--- a/app/Database/Repository/WordPressCustomTable.php
+++ b/app/Database/Repository/WordPressCustomTable.php
@@ -73,6 +73,9 @@ class WordPressCustomTable extends AbstractRepository {
 
 		foreach ( $params as $key => $value ) {
 			switch ( $key ) {
+				case 'order_by':
+					// skip, handled below
+					break;
 				default:
 					if ( $this->is_valid_key( $class, $key ) ) {
 						$query .= $wpdb->prepare(
@@ -80,6 +83,15 @@ class WordPressCustomTable extends AbstractRepository {
 							$value
 						);
 					}
+			}
+		}
+
+		if ( isset( $params['order_by'] ) ) {
+			// @todo find a better way of whitelisting order_by
+			switch ( $params['order_by'] ) {
+				case 'ID':
+					$query .= " ORDER BY {$params['order_by']} DESC";
+					break;
 			}
 		}
 

--- a/app/Jobs/AbstractJob.php
+++ b/app/Jobs/AbstractJob.php
@@ -190,6 +190,7 @@ abstract class AbstractJob implements Job {
 	 */
 	public function runs() {
 		return $this->em->find_by( Klass::RUN, array(
+			'order_by' => 'ID',
 			'job' => $this->slug(),
 		) );
 	}


### PR DESCRIPTION
This is a terrible way of going about it, but it at least it makes itself as
a note that we need to support this. We'll need to rethink the API for
the EntityManager to ensure we support this properly across all the
repositories.

Fixes #225.