### PR TITLE
Remove color: inherit

### DIFF
--- a/client/components/editor/instance/index.scss
+++ b/client/components/editor/instance/index.scss
@@ -28,7 +28,6 @@
                     border: none;
 
                     &:hover {
-                        color: inherit;
                         text-decoration: none;
                     }
                 }


### PR DESCRIPTION
This is setting the color incorrectly on hover.

Fixes #222.