### PR TITLE
Only reset selection if changes

### DIFF
--- a/client/components/Editor/Code.tsx
+++ b/client/components/Editor/Code.tsx
@@ -70,6 +70,10 @@ const mapKeydownToAction = (
 
 const setSelectionRange = (node: Element, ss: number, se: number) =>
   Kefir.stream<never, never>(emitter => {
+    if (ss === selectSelectionStart(node) && se === selectSelectionEnd(node)) {
+      return emitter.end();
+    }
+
     const range = document.createRange();
     const offsetStart = findOffset(node, ss);
     let offsetEnd = offsetStart;


### PR DESCRIPTION
Check the current position of the selection before updating,
allowing the browser to maintain most of the control over
the cursor.

Fixes #147.