### PR TITLE
Add line numbers to the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This change log follows the [Keep a Changelog standards](http://keepachangelog.com/). Versions follows [Semantic Versioning](http://semver.org/).
 
+### [Unreleased][unreleased] ###
+
+#### Added ####
+
+* Added line numbers to the editor
+
 ### [1.1.1][] - 2018-06-28 ###
 
 * Fixed buggy deploy

--- a/client/components/Blob/Code.tsx
+++ b/client/components/Blob/Code.tsx
@@ -13,13 +13,7 @@ const updatePrism = (prism: Props['prism']) =>
   ]);
 
 const Code: React.RefForwardingComponent<HTMLElement, Props> = (props, ref) => (
-  <code
-    ref={ref}
-    className={`language-${prismSlug(props.blob.language)}`}
-    style={{
-      padding: '0'
-    }}
-  >
+  <code ref={ref} className={`language-${prismSlug(props.blob.language)}`}>
     {props.blob.code}
   </code>
 );

--- a/client/components/Editor/Pre.tsx
+++ b/client/components/Editor/Pre.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { prismSlug } from '../../helpers';
 
 const Pre: React.FC<{ language: string }> = ({ language, children }) => (
-  <pre className={`language-${prismSlug(language)}`} spellCheck={false}>
+  <pre
+    className={`language-${prismSlug(language)} line-numbers`}
+    spellCheck={false}
+  >
     {children}
   </pre>
 );

--- a/client/components/Editor/index.scss
+++ b/client/components/Editor/index.scss
@@ -43,4 +43,44 @@
             display: initial;
         }
     }
+
+    .line-numbers .line-numbers-rows {
+        font-size: 16px;
+        top: 50%;
+        left: -0.25em;
+        transform: translateY(-50%);
+    }
+
+    &.wpgp-editor-theme- {
+        &cb {
+            .line-numbers-rows span {
+                padding-right: 0;
+            }
+        }
+
+        &ghcolors {
+            .line-numbers .line-numbers-rows {
+                line-height: 1.2;
+            }
+        }
+
+        &coy {
+            pre[class*="language-"].line-numbers.line-numbers code {
+                padding-left: 3.8em;
+                display: block;
+            }
+
+            pre[class*="language-"].line-numbers.line-numbers {
+                position: relative;
+            }
+
+            .line-numbers .line-numbers-rows {
+                left: 0.75em;
+            }
+        }
+    }
+
+    pre[class*="language-"].line-numbers {
+        position: static;
+    }
 }

--- a/client/components/Editor/index.tsx
+++ b/client/components/Editor/index.tsx
@@ -85,7 +85,7 @@ const Editor: React.FC<Props> = ({
   onLanguageChange,
   onDeleteClick
 }) => (
-  <div className="editor page">
+  <div className={`editor page wpgp-editor-theme-${theme}`}>
     <div className="code-toolbar">
       <Toolbar>
         <Filename filename={filename} onInput={onFilenameChange} />

--- a/client/prismjs.d.ts
+++ b/client/prismjs.d.ts
@@ -18,6 +18,10 @@ declare module 'prismjs/components/prism-core' {
     [key: string]: {};
   }
 
+  interface Environment {
+    element: HTMLElement;
+  }
+
   interface PrismCore {
     highlightAll(): void;
     highlightElement(
@@ -25,6 +29,9 @@ declare module 'prismjs/components/prism-core' {
       async?: boolean,
       callback?: Function
     ): void;
+    hooks: {
+      add(event: string, callback: (env: Environment) => void): void;
+    };
     plugins: Plugins;
     languages: Languages;
   }


### PR DESCRIPTION
Add a hack to the highlighting step to move around
the line numbers element and put it where we want.
Also hacking around the CSS a bit here too, but it
does work smoothly.

Fixes #71.