### PR TITLE
Escape filename on BE & FE

### DIFF
--- a/client/prism/plugins/filename.ts
+++ b/client/prism/plugins/filename.ts
@@ -14,13 +14,13 @@ Prism.plugins.toolbar.registerButton('filename', function filenameButton(env) {
     return;
   }
 
-  const text = pre.getAttribute('data-filename') || null;
+  const text = pre.getAttribute('data-filename');
 
   if (text == null) {
     return;
   }
 
-  filename.innerHTML = text;
+  filename.textContent = text;
 
   return filename;
 });

--- a/views/blob.php
+++ b/views/blob.php
@@ -5,7 +5,7 @@ return sprintf(
     isset( $data['prism']['line-numbers'] ) && $data['prism']['line-numbers'] ? ' line-numbers' : '',
     isset( $data['blob']['highlight'] ) && $data['blob']['highlight'] ? ' data-line="' . $data['blob']['highlight'] .'"' : '',
     isset( $data['blob']['edit_url'] ) && $data['blob']['edit_url'] ? ' data-edit-url="' . $data['blob']['edit_url'] .'"' : '',
-    $data['blob']['filename'],
+    htmlspecialchars( $data['blob']['filename'] ),
     $this->prism_slug( $data['blob']['language']['slug'] ),
     $data['blob']['code']
 );


### PR DESCRIPTION
Use `htmlspecialchars` & `textContent` to ensure HTML entities
don't get output as-is on the FE.

Fixes #324.