### PR TITLE
Allow alt + tab to escape the editor

### DIFF
--- a/client/components/Editor/util.ts
+++ b/client/components/Editor/util.ts
@@ -27,7 +27,7 @@ export function isSpecialEvent(
 
   switch (evt.keyCode) {
     case 9: // Tab
-      if (!cmdOrCtrl) {
+      if (!cmdOrCtrl && !altKey) {
         return true;
       }
       break;


### PR DESCRIPTION
This works on OSX. We'll need to test this on Windows.

Fixes #321.