### PR TITLE
Improve border of focused controls

### DIFF
--- a/client/components/EditPage/Controls.scss
+++ b/client/components/EditPage/Controls.scss
@@ -1,5 +1,9 @@
 @import "./common";
 
+body.post-type-gistpen {
+    background: #FFF;
+}
+
 #wpbody .wpgp-editor-controls {
     max-width: 100%;
     margin-left: auto;
@@ -44,6 +48,7 @@
         font-weight: inherit;
         margin-left: 4px;
         margin-right: 4px;
+        outline: none;
 
         &::before {
             margin-right: 0.25em;
@@ -291,6 +296,7 @@
         $select-text: #1d1f21,
         $select-background: #A8FF60,
         $checkbox-border: #FFF,
-        $checked-color: #DAD085
+        $checked-color: #DAD085,
+        $controls-radius: true
     );
 }

--- a/client/components/EditPage/Controls.tsx
+++ b/client/components/EditPage/Controls.tsx
@@ -164,12 +164,16 @@ const Controls: React.FC<Props> = ({
       >
         {i18n('editor.update')}
       </button>
+    </div>
+    <div className="wpgp-editor-control">
       <button
         className="dashicons-before wpgp-button wpgp-button-add"
         onClick={onAddClick}
       >
         {i18n('editor.file.add')}
       </button>
+    </div>
+    <div className="wpgp-editor-control">
       <a
         href={link('wpgp_route', 'commits')}
         className="dashicons-before wpgp-button wpgp-button-add"

--- a/client/components/EditPage/Controls.tsx
+++ b/client/components/EditPage/Controls.tsx
@@ -59,6 +59,21 @@ type Props = {
 
 const toggleToBoolean = (toggle: Toggle): boolean => toggle === 'on';
 
+const ButtonControl: React.FC<{
+  className: string;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  children: React.ReactNode;
+}> = ({ className, onClick, children }) => (
+  <div className="wpgp-editor-control">
+    <button
+      className={`dashicons-before wpgp-button ${className}`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  </div>
+);
+
 const Controls: React.FC<Props> = ({
   selectedTheme,
   selectedStatus,
@@ -157,22 +172,14 @@ const Controls: React.FC<Props> = ({
       />
     </div>
 
-    <div className="wpgp-editor-control">
-      <button
-        className="dashicons-before wpgp-button wpgp-button-update"
-        onClick={onUpdateClick}
-      >
-        {i18n('editor.update')}
-      </button>
-    </div>
-    <div className="wpgp-editor-control">
-      <button
-        className="dashicons-before wpgp-button wpgp-button-add"
-        onClick={onAddClick}
-      >
-        {i18n('editor.file.add')}
-      </button>
-    </div>
+    <ButtonControl className="wpgp-button-update" onClick={onUpdateClick}>
+      {i18n('editor.update')}
+    </ButtonControl>
+
+    <ButtonControl className="wpgp-button-add" onClick={onAddClick}>
+      {i18n('editor.file.add')}
+    </ButtonControl>
+
     <div className="wpgp-editor-control">
       <a
         href={link('wpgp_route', 'commits')}

--- a/client/components/EditPage/Description.scss
+++ b/client/components/EditPage/Description.scss
@@ -33,11 +33,11 @@
     box-sizing: border-box;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
     cursor: pointer;
+    outline: none;
 
     &:focus {
         border: 1px solid $light-blue;
-
-        @include focus-border();
+        box-shadow: 0 0 2px $dark-blue;
     }
 
     &::before {

--- a/client/components/EditPage/common.scss
+++ b/client/components/EditPage/common.scss
@@ -6,11 +6,6 @@ $dark-blue: #1E8CBE;
 $light-blue: #5B9DD9;
 
 // Mixins
-
-@mixin focus-border {
-    box-shadow: 0 0 2px $dark-blue;
-}
-
 @mixin editor-controls-theme(
     $theme,
     $controls-background,
@@ -31,14 +26,19 @@ $light-blue: #5B9DD9;
 
         @if $controls-border {
             border: 0.3em solid $controls-border;
+        }
 
-            @if $controls-radius {
-                border-radius: 0.5em;
-            }
+        @if $controls-radius {
+            border-radius: 0.5em;
         }
 
         .wpgp-editor-control {
             background-color: $control-background;
+            border: 2px solid transparent;
+
+            &:focus-within {
+                border-color: $controls-text;
+            }
         }
 
         .wpgp-button {


### PR DESCRIPTION
Use the text color for the outline color when a control is focused.

Fixes #320.