### PR TITLE
Use trusty dist on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+dist: trusty
 
 php:
     - 5.4


### PR DESCRIPTION
This OS version supports the PHP versions
we need to continue running our tests.