### PR TITLE
Add StrictParams

### DIFF
--- a/app/Http/RepoController.php
+++ b/app/Http/RepoController.php
@@ -78,12 +78,7 @@ class RepoController {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function create( WP_REST_Request $request ) {
-		try {
-			/** @var Repo|WP_Error $model */
-			$model = $this->em->create( EntityManager::REPO_CLASS, $request->get_params() );
-		} catch( GuardedPropertyException $e ) {
-			return $this->guarded_exception_to_error( $e );
-		}
+		$model = $this->em->create( EntityManager::REPO_CLASS, $request->get_params() );
 
 		if ( is_wp_error( $model ) ) {
 			$model->add_data( array( 'status' => 500 ) );
@@ -255,30 +250,5 @@ class RepoController {
 		}
 
 		return new WP_REST_Response( null, 204 );
-	}
-
-	/**
-	 * Convert the GuardedPropertyException to a WP_Error.
-	 *
-	 * @param  GuardedPropertyException $e Thrown exception.
-	 * @return WP_Error                    Mapped error.
-	 */
-	private function guarded_exception_to_error( GuardedPropertyException $e ) {
-		return new WP_Error(
-			'rest_invalid_param',
-			sprintf(
-				__( 'Invalid parameter: %s', 'wp-gistpen' ),
-				$e->property
-			),
-			[
-				'status' => 400,
-				'params' => [
-					$e->property => sprintf(
-						__( 'Param "%s" is not valid.', 'wp-gistpen' ),
-						$e->property
-					),
-				]
-			]
-		);
 	}
 }

--- a/app/Http/StrictParams.php
+++ b/app/Http/StrictParams.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Intraxia\Gistpen\Http;
+
+use Intraxia\Jaxion\Contract\Core\HasFilters;
+use Intraxia\Gistpen\Model\Commit;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class StrictParams
+ *
+ * Removes any unregistered params from incoming requests.
+ *
+ * @package    Intraxia\Gistpen
+ * @subpackage Http
+ * @since      2.0.0
+ */
+class StrictParams implements HasFilters {
+	/**
+	 * Removes any arguments from the request that aren't set in its `args.`
+	 * This ensures any registered controller has a correctly matching
+	 * sanitization param for all the expected parameters.
+	 *
+	 * @param  null|WP_Error|WP_REST_Response $response The response to send the the BE.
+	 *                                                  Probably null, as the request hasn't been handled.
+	 * @param  callable                       $handler  Request handler.
+	 * @param  WP_REST_Request                $request  The currentl processing request.
+	 * @return null|WP_Error|WP_REST_Response           The final response.
+	 */
+	public function filter_unregistered_params( $response, $handler, WP_REST_Request $request ) {
+		if ( strpos( $request->get_route(), 'intraxia/v1/gistpen' ) === false ) {
+			return $response;
+		}
+
+		$attributes = $request->get_attributes();
+
+		// @TODO(mAAdhaTTah) once args is on all routes,
+		// return error if this isn't set,
+		// or make this configurable
+		if ( ! isset( $attributes['args'] ) ) {
+			return $response;
+		}
+
+		$invalid_params = [];
+
+		foreach ( $request->get_params() as $key => $value ) {
+			if ( ! isset( $attributes['args'][ $key ] ) ) {
+				$invalid_params[ $key ] = sprintf(
+					__( 'Param "%s" is not a valid request param.', 'wp-gistpen' ),
+					$key
+				);
+			}
+		}
+
+		if ( $invalid_params ) {
+			if ( is_wp_error( $response ) ) {
+				$data = $response->get_error_data();
+				$invalid_params = array_merge( $data['params'], $invalid_params );
+			}
+
+			return new WP_Error(
+				'rest_invalid_param',
+				sprintf(
+					__( 'Invalid parameter(s): %s' ),
+					implode( ', ', array_keys( $invalid_params ) )
+				),
+				array(
+					'status' => 400,
+					'params' => $invalid_params,
+				)
+			);
+		}
+
+		return $response;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function filter_hooks() {
+		return [
+			[
+				'hook'   => 'rest_request_before_callbacks',
+				'method' => 'filter_unregistered_params',
+				'args'   => 3,
+			],
+		];
+	}
+}

--- a/app/Providers/ControllerServiceProvider.php
+++ b/app/Providers/ControllerServiceProvider.php
@@ -9,6 +9,7 @@ use Intraxia\Gistpen\Http\StateController;
 use Intraxia\Gistpen\Http\UserController;
 use Intraxia\Gistpen\Http\RepoController;
 use Intraxia\Gistpen\Http\BlobController;
+use Intraxia\Gistpen\Http\StrictParams;
 use Intraxia\Jaxion\Contract\Core\Container;
 use Intraxia\Jaxion\Contract\Core\ServiceProvider;
 
@@ -53,6 +54,9 @@ class ControllerServiceProvider implements ServiceProvider {
 		$container->share( array( 'controller.state' => 'Intraxia\Gistpen\Http\BlobController' ), function( Container $container) {
 			return new StateController( $container->fetch( 'database' ) );
 		} );
-
+		// @TODO(mAAdhaTTah) move this to own provider?
+		$container->share( [ 'http.strict' => StrictParams::class ], function() {
+			return new StrictParams;
+		});
 	}
 }

--- a/test/Integration/Repo/CreateTest.php
+++ b/test/Integration/Repo/CreateTest.php
@@ -94,11 +94,37 @@ class CreateTest extends TestCase {
 		$this->assertResponseStatus( $response, 400 );
 		$this->assertResponseData( $response, [
 			'code' => 'rest_invalid_param',
-			'message' => 'Invalid parameter: extra',
+			'message' => 'Invalid parameter(s): extra',
 			'data' => [
 				'status' => 400,
 				'params' => [
-					'extra' => 'Param "extra" is not valid.'
+					'extra' => 'Param "extra" is not a valid request param.',
+				]
+			]
+		] );
+	}
+
+	public function test_returns_combines_errors_of_extra_and_invalid_params() {
+		$this->set_role( 'administrator' );
+		$repo = $this->fm->instance( Repo::class );
+		$request = new WP_REST_Request( 'POST', '/intraxia/v1/gistpen/repos' );
+		$request->set_body_params( [
+			'description' => 123,
+			'status'      => $repo->status,
+			'extra'       => 'value',
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertResponseStatus( $response, 400 );
+		$this->assertResponseData( $response, [
+			'code' => 'rest_invalid_param',
+			'message' => 'Invalid parameter(s): description, extra',
+			'data' => [
+				'status' => 400,
+				'params' => [
+					'description' => 'Param "description" must be a string.',
+					'extra' => 'Param "extra" is not a valid request param.',
 				]
 			]
 		] );


### PR DESCRIPTION
When registered, any params not registered with `args` with
be removed from the incoming request. Added tests to ensure
it works with the Repo controller.