### PR TITLE
Create the root Block component

### DIFF
--- a/client/components/Block/__tests__/Block.spec.tsx
+++ b/client/components/Block/__tests__/Block.spec.tsx
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import { render, RenderResult } from '@testing-library/react';
+import { createRender } from 'react-testing-kit';
+import { Block } from '../';
+
+const renderBlock = createRender({
+  defaultProps: {
+    className: '',
+    setAttributes: jest.fn(),
+    blobId: null,
+    repoId: null
+  },
+  component: Block,
+  render,
+  elements: ({ getByTestId }: RenderResult) => ({
+    setEmbed: () => getByTestId('set-embed'),
+    editEmbed: () => getByTestId('edit-embed')
+  }),
+  fire: () => ({}),
+  waitFor: () => ({})
+});
+
+describe('Block', () => {
+  it('should render setEmbed with no values', () => {
+    const { elements } = renderBlock();
+
+    expect(elements.setEmbed()).toBeInTheDocument();
+  });
+
+  it('should render setEmbed with only blobId', () => {
+    const { elements } = renderBlock({ blobId: 123 });
+
+    expect(elements.setEmbed()).toBeInTheDocument();
+  });
+
+  it('should render edit embed with both repoId & blobId', () => {
+    const { elements } = renderBlock({ repoId: 123, blobId: 456 });
+
+    expect(elements.editEmbed()).toBeInTheDocument();
+  });
+});

--- a/client/components/Block/__tests__/state.spec.ts
+++ b/client/components/Block/__tests__/state.spec.ts
@@ -1,0 +1,16 @@
+import { reducer } from '../state';
+
+describe('state', () => {
+  describe('reducer', () => {
+    it('should return the same state on random actions', () => {
+      const initialState = {
+        status: 'set-embed',
+        repoId: null,
+        blobId: null
+      } as const;
+      expect(reducer(initialState, { type: '@@RANDOM' } as any)).toEqual(
+        initialState
+      );
+    });
+  });
+});

--- a/client/components/Block/index.tsx
+++ b/client/components/Block/index.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect } from 'react';
+import { useDelta, Delta, RootJunction, unreachable } from 'brookjs';
+import Kefir from 'kefir';
+import { RootAction } from '../../util';
+import { reducer, initialState, State, Attributes } from './state';
+
+const rootDelta: Delta<RootAction, State> = () => Kefir.never();
+
+export const Block: React.FC<Attributes & {
+  className: string;
+  setAttributes: (attributes: Partial<Attributes>) => void;
+}> = ({ className, blobId, repoId, setAttributes }) => {
+  const { state, root$ } = useDelta(
+    reducer,
+    initialState({ repoId, blobId }),
+    rootDelta
+  );
+
+  useEffect(() => {
+    setAttributes({ repoId: state.repoId });
+  }, [setAttributes, state.repoId]);
+
+  useEffect(() => {
+    setAttributes({ blobId: state.blobId });
+  }, [setAttributes, state.blobId]);
+
+  let children: JSX.Element;
+
+  switch (state.status) {
+    case 'set-embed':
+      children = <div data-testid="set-embed">Create or choose</div>;
+      break;
+    case 'edit-embed':
+      children = <div data-testid="edit-embed">Edit blob</div>;
+      break;
+    /* istanbul ignore next */
+    default:
+      return unreachable(state);
+  }
+
+  return (
+    <RootJunction root$={root$}>
+      <div className={className}>{children}</div>
+    </RootJunction>
+  );
+};

--- a/client/components/Block/state.tsx
+++ b/client/components/Block/state.tsx
@@ -1,0 +1,48 @@
+import { EddyReducer, Maybe } from 'brookjs';
+import { RootAction } from '../../util';
+
+export type SetEmbed = {
+  status: 'set-embed';
+  repoId: Maybe<number>;
+  blobId: Maybe<number>;
+};
+
+export type EditBlob = {
+  status: 'edit-embed';
+  repoId: number;
+  blobId: number;
+};
+
+export type State = SetEmbed | EditBlob;
+
+export type Attributes = {
+  blobId: Maybe<number>;
+  repoId: Maybe<number>;
+};
+
+// @TODO(mAAdhaTTah) remove duplicate types on params (implicit any?!)
+export const reducer: EddyReducer<State, RootAction> = (
+  state: State,
+  action: RootAction
+) => {
+  switch (action.type) {
+    default:
+      return state;
+  }
+};
+
+export const initialState = ({ blobId, repoId }: Attributes): State => {
+  if (blobId == null || repoId == null) {
+    return {
+      status: 'set-embed',
+      repoId,
+      blobId
+    } as const;
+  } else {
+    return {
+      status: 'edit-embed',
+      repoId,
+      blobId
+    } as const;
+  }
+};

--- a/client/components/index.ts
+++ b/client/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Block';
 export { default as Commits } from './Commits';
 export { default as EditPage } from './EditPage';
 export { default as SearchPopup } from './SearchPopup';


### PR DESCRIPTION
This will be registered with WordPress as the new Gutenberg block
for WP-Gistpen. This ensures the various states are rendered
correctly based on what values are currently saved in the block.