### PR TITLE
Add TextControl component from WP components

### DIFF
--- a/client/actions/form.ts
+++ b/client/actions/form.ts
@@ -1,0 +1,5 @@
+import { createAction } from 'typesafe-actions';
+
+export const change = createAction('CHANGE', resolve => (value: string) =>
+  resolve({ value })
+);

--- a/client/actions/index.ts
+++ b/client/actions/index.ts
@@ -4,6 +4,7 @@ export * from './author';
 export * from './block';
 export * from './commits';
 export * from './editor';
+export * from './form';
 export * from './highlighting';
 export * from './init';
 export * from './jobs';

--- a/client/components/TextControl.tsx
+++ b/client/components/TextControl.tsx
@@ -1,0 +1,10 @@
+import { toJunction } from 'brookjs';
+import { TextControl } from '@wordpress/components';
+import { Stream } from 'kefir';
+import { change } from '../actions';
+
+const events = {
+  onChange: (e$: Stream<string, never>) => e$.map(change)
+};
+
+export default toJunction(events)(TextControl);


### PR DESCRIPTION
This allows us to use the component with other brookjs components.