### PR TITLE
Activate plugin on test start

### DIFF
--- a/app/Lifecycle.php
+++ b/app/Lifecycle.php
@@ -46,14 +46,23 @@ class Lifecycle implements HasActions {
 		}
 
 		update_option( '_wpgp_activated', 'done' );
-		flush_rewrite_rules( true );
+		$this->flush_on_shutdown();
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
 	public function deactivate() {
-		flush_rewrite_rules( true );
+		$this->flush_on_shutdown();
+	}
+
+	/**
+	 * Flush the application rewrite as the app shuts down.
+	 */
+	protected function flush_on_shutdown() {
+		add_action( 'shutdown', function() {
+			flush_rewrite_rules( true );
+		});
 	}
 
 	/**

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -6,6 +6,9 @@
  * @package Intraxia\Gistpen\Test
  */
 
+use Intraxia\Gistpen\Lifecycle;
+use function Intraxia\Gistpen\container;
+
 $plugin_root = dirname( dirname( __FILE__ ) );
 $_tests_dir  = getenv( 'WP_TESTS_DIR' );
 
@@ -58,6 +61,8 @@ $_manually_load_plugin = function() use ( $plugin_root ) {
 	);
 
 	require $plugin_root . '/wp-gistpen.php';
+
+	container()->get( Lifecycle::class )->activate();
 };
 
 tests_add_filter( 'muplugins_loaded', $_manually_load_plugin );


### PR DESCRIPTION
This creates the tables needed to correctly run the tests for the
Jobs & Runs logging.