### PR TITLE
Fix the actions emitted by Search

### DIFF
--- a/client/__tests__/__snapshots__/storyshots.spec.ts.snap
+++ b/client/__tests__/__snapshots__/storyshots.spec.ts.snap
@@ -7870,6 +7870,7 @@ exports[`Storyshots Search View Error 1`] = `
           </label>
           <input
             class="components-text-control__input"
+            data-testid="search-input"
             id="inspector-text-control-4"
             type="text"
             value="javascript"
@@ -8125,6 +8126,7 @@ exports[`Storyshots Search View Found No Snippets 1`] = `
           </label>
           <input
             class="components-text-control__input"
+            data-testid="search-input"
             id="inspector-text-control-2"
             type="text"
             value="javascript"
@@ -8382,6 +8384,7 @@ exports[`Storyshots Search View Found Snippets 1`] = `
           </label>
           <input
             class="components-text-control__input"
+            data-testid="search-input"
             id="inspector-text-control-3"
             type="text"
             value="javascript"
@@ -8653,6 +8656,7 @@ exports[`Storyshots Search View Initial 1`] = `
           </label>
           <input
             class="components-text-control__input"
+            data-testid="search-input"
             id="inspector-text-control-0"
             type="text"
             value="javascript"
@@ -8908,6 +8912,7 @@ exports[`Storyshots Search View Reerror 1`] = `
           </label>
           <input
             class="components-text-control__input"
+            data-testid="search-input"
             id="inspector-text-control-6"
             type="text"
             value="javascript"
@@ -9188,6 +9193,7 @@ exports[`Storyshots Search View Researching 1`] = `
           </label>
           <input
             class="components-text-control__input"
+            data-testid="search-input"
             id="inspector-text-control-5"
             type="text"
             value="javascript"
@@ -9474,6 +9480,7 @@ exports[`Storyshots Search View Searching 1`] = `
           </label>
           <input
             class="components-text-control__input"
+            data-testid="search-input"
             id="inspector-text-control-1"
             type="text"
             value="javascript"

--- a/client/search/Choosing.tsx
+++ b/client/search/Choosing.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ofType, useDelta, RootJunction, toJunction, Delta } from 'brookjs';
 import Kefir from 'kefir';
 import { RootAction } from '../util';
-import { searchBlobSelected } from './actions';
+import { searchBlobSelected, searchRepoSelected } from './actions';
 import { View } from './View';
 import { reducer, initialState, State, Collection } from './state';
 import { searchDelta } from './delta';
@@ -34,7 +34,12 @@ const Choosing: React.FC<{ collection: Collection }> = ({ collection }) => {
   return (
     <RootJunction root$={root$}>
       <View
-        placeholderLabel="placeholder.js"
+        searchLabel={
+          collection === 'blobs' ? 'Search snippets' : 'Search repos'
+        }
+        placeholderLabel={
+          collection === 'blobs' ? 'placeholder.js' : 'Placeholder Repo Name'
+        }
         term={state.term}
         isLoading={isLoading(state)}
         error={hasError(state) ? state.error : null}
@@ -67,6 +72,6 @@ const Choosing: React.FC<{ collection: Collection }> = ({ collection }) => {
 
 export default toJunction(
   {},
-  action$ => action$.thru(ofType(searchBlobSelected)),
+  action$ => action$.thru(ofType(searchBlobSelected, searchRepoSelected)),
   // @TODO(mAAdhaTTah) fix cast!
 )(Choosing as any) as React.FC<{ collection: Collection }>;

--- a/client/search/View.tsx
+++ b/client/search/View.tsx
@@ -19,19 +19,21 @@ type ResultView = {
 };
 
 export const View: React.FC<{
+  searchLabel: string;
   placeholderLabel: string;
   term: string;
   isLoading?: boolean;
   error?: Maybe<string>;
   results?: Maybe<ResultView[]>;
-}> = ({ placeholderLabel, term, isLoading, error, results }) => {
+}> = ({ searchLabel, placeholderLabel, term, isLoading, error, results }) => {
   return (
     <div data-testid="choosing">
       <div className={styles.search}>
         <TextControl
           className={styles.grow}
-          label="Search for snippet"
+          label={searchLabel}
           value={term}
+          data-testid="search-input"
           preplug={e$ =>
             e$.thru(ofType(change)).map(a => searchInput(a.payload.value))
           }

--- a/client/search/__stories__/View.stories.tsx
+++ b/client/search/__stories__/View.stories.tsx
@@ -22,25 +22,40 @@ const results = searchBlobsApiResponse.map(resp => ({
 
 export const initial = () => (
   <div className="wp-block" style={{ margin: '0 auto' }}>
-    <View placeholderLabel="placeholder.js" term="javascript" />
+    <View
+      searchLabel="Search for snippet"
+      placeholderLabel="placeholder.js"
+      term="javascript"
+    />
   </div>
 );
 
 export const searching = () => (
   <div className="wp-block" style={{ margin: '0 auto' }}>
-    <View placeholderLabel="placeholder.js" term="javascript" isLoading />
+    <View
+      searchLabel="Search for snippet"
+      placeholderLabel="placeholder.js"
+      term="javascript"
+      isLoading
+    />
   </div>
 );
 
 export const foundNoSnippets = () => (
   <div className="wp-block" style={{ margin: '0 auto' }}>
-    <View placeholderLabel="placeholder.js" term="javascript" results={[]} />
+    <View
+      searchLabel="Search for snippet"
+      placeholderLabel="placeholder.js"
+      term="javascript"
+      results={[]}
+    />
   </div>
 );
 
 export const foundSnippets = () => (
   <div className="wp-block" style={{ margin: '0 auto' }}>
     <View
+      searchLabel="Search for snippet"
       placeholderLabel="placeholder.js"
       term="javascript"
       results={results}
@@ -51,6 +66,7 @@ export const foundSnippets = () => (
 export const error = () => (
   <div className="wp-block" style={{ margin: '0 auto' }}>
     <View
+      searchLabel="Search for snippet"
       placeholderLabel="placeholder.js"
       term="javascript"
       error="Search failed."
@@ -61,6 +77,7 @@ export const error = () => (
 export const researching = () => (
   <div className="wp-block" style={{ margin: '0 auto' }}>
     <View
+      searchLabel="Search for snippet"
       placeholderLabel="placeholder.js"
       term="javascript"
       results={results}
@@ -72,6 +89,7 @@ export const researching = () => (
 export const reerror = () => (
   <div className="wp-block" style={{ margin: '0 auto' }}>
     <View
+      searchLabel="Search for snippet"
       placeholderLabel="placeholder.js"
       term="javascript"
       error="Search failed."

--- a/client/search/__tests__/Choosing.spec.tsx
+++ b/client/search/__tests__/Choosing.spec.tsx
@@ -14,12 +14,11 @@ import { createSearchBlob, createSearchRepo } from '../../mocks';
 
 const createInstance = ({
   container,
-  getByLabelText,
   getByText,
   getByTestId,
 }: RenderResult) => {
   const elements = {
-    input: () => getByLabelText('Search for snippet'),
+    input: () => getByTestId('search-input'),
     snippetList: () => getByTestId('snippet-list'),
     selectButton: () => getByText('Select'),
     errorNotice: () => container.querySelector('.components-notice.is-error'),

--- a/client/search/actions.ts
+++ b/client/search/actions.ts
@@ -24,11 +24,11 @@ export const search = createAsyncAction(
 )<void, SearchApiResponse, TypeError | AjaxError, void>();
 
 export const searchBlobSelected = createAction(
-  'SNIPPET_SELECTED',
+  'SEARCH_BLOB_SELECTED',
   resolve => (blob: SearchBlob) => resolve({ blob }),
 );
 
 export const searchRepoSelected = createAction(
-  'SNIPPET_SELECTED',
+  'SEARCH_REPO_SELECTED',
   resolve => (repo: SearchRepo) => resolve({ repo }),
 );


### PR DESCRIPTION
`search{Blob,Repo}Selected` actions accidentally shared a string
constant. This splits them up and fixes the stream API exposed.
Also change the label based upon which collection is active.