### PR TITLE
Provide Globals to Block

### DIFF
--- a/app/Params/Globals.php
+++ b/app/Params/Globals.php
@@ -131,6 +131,10 @@ class Globals implements HasFilters {
 	public function filter_hooks() {
 		return array(
 			array(
+				'hook'   => 'params.state.globals',
+				'method' => 'apply_globals',
+			),
+			array(
 				'hook'   => 'params.state.button',
 				'method' => 'apply_globals',
 			),

--- a/app/View/Button.php
+++ b/app/View/Button.php
@@ -92,7 +92,7 @@ class Button implements HasFilters {
 	 * Output the default state used by the TinyMCE plugin in a script tag.
 	 */
 	public function output_tinymce_state() {
-		echo $this->tmpl->render( 'tinymce', $this->params->state( 'button' ) );  // @codingStandardsIgnoreLine
+		echo $this->tmpl->render( 'globals', $this->params->state( 'globals' ) );  // @codingStandardsIgnoreLine
 	}
 
 	/**

--- a/client/block/config.tsx
+++ b/client/block/config.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Block as BlockConfig } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { Shortcode } from '../wp';
+import { GlobalsProvider } from '../globals';
 import { Attributes } from './state';
 import { Block } from './Block';
 
@@ -34,12 +35,14 @@ export const edit: Config['edit'] = ({
   setAttributes,
 }) => {
   return (
-    <Block
-      className={className}
-      repoId={attributes.repoId}
-      blobId={attributes.blobId}
-      setAttributes={setAttributes}
-    />
+    <GlobalsProvider value={window.__GISTPEN_GLOBALS__}>
+      <Block
+        className={className}
+        repoId={attributes.repoId}
+        blobId={attributes.blobId}
+        setAttributes={setAttributes}
+      />
+    </GlobalsProvider>
   );
 };
 

--- a/client/globals/index.ts
+++ b/client/globals/index.ts
@@ -1,8 +1,11 @@
+import { GlobalsState } from './state';
+
 export * from './context';
 export * from './state';
 
 declare global {
   interface Window {
+    __GISTPEN_GLOBALS__: GlobalsState;
     __GISTPEN_I18N__?: { [key: string]: string };
     __webpack_public_path__?: string;
   }

--- a/resources/views/globals.php
+++ b/resources/views/globals.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Renders the application globals.
+ *
+ * @package Intraxia\Gistpen
+ * @var string
+ */
+
+return '<script type="application/javascript">window.__GISTPEN_GLOBALS__ = ' . wp_json_encode( $data['globals'] ) . ';</script>';

--- a/resources/views/tinymce.php
+++ b/resources/views/tinymce.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Renders the settings for the TinyMCE plugin.
- *
- * @package Intraxia\Gistpen
- * @var string
- */
-
-return '<script type="application/javascript">window.__GISTPEN_TINYMCE__ = ' . wp_json_encode( $data ) . ';</script>';


### PR DESCRIPTION
The Edit block needs the GlobalsProvider to link the values from
the server to the application. This updates the server to provide
the globals as `__GISTPEN_GLOBALS__` and updates the `edit`
function in the block to wrap the `Edit` component with the
Provider.