### PR TITLE
Create BaseFilter for reuse

### DIFF
--- a/app/Http/Filter/BaseFilter.php
+++ b/app/Http/Filter/BaseFilter.php
@@ -1,0 +1,37 @@
+<?php
+namespace Intraxia\Gistpen\Http\Filter;
+
+use Intraxia\Jaxion\Contract\Http\Filter as FilterContract;
+use WP_Error;
+
+/**
+ * Class Filter\BaseFilter
+ *
+ * @package Intraxia\Gistpen\Http
+ * @subpackage Filters
+ */
+abstract class BaseFilter implements FilterContract {
+	/**
+	 * Create validation error to return.
+	 *
+	 * @param  string $message Validation message.
+	 * @return WP_Error        Validation error.
+	 */
+	protected function create_error( $message ) {
+		return new WP_Error( 'rest_invalid_param', $message );
+	}
+
+	/**
+	 * Sanitize the entity with the filter's validation rules
+	 *
+	 * @param  array  $entity Entity to validate.
+	 * @param  string $name   Name property to use for validation.
+	 * @return WP_Error       Validation error.
+	 */
+	protected function sanitize_entity( array $entity, $name = '' ) {
+		return rest_validate_value_from_schema( $entity, [
+			'type'       => 'object',
+			'properties' => $this->rules(),
+		], $name );
+	}
+}

--- a/app/Http/Filter/RepoCollection.php
+++ b/app/Http/Filter/RepoCollection.php
@@ -1,7 +1,6 @@
 <?php
 namespace Intraxia\Gistpen\Http\Filter;
 
-use Intraxia\Jaxion\Contract\Http\Filter as FilterContract;
 use WP_Error;
 
 /**
@@ -10,7 +9,7 @@ use WP_Error;
  * @package Intraxia\Gistpen\Http
  * @subpackage Filters
  */
-class RepoCollection implements FilterContract {
+class RepoCollection extends BaseFilter {
 	/**
 	 * Generates argument rules.
 	 *

--- a/app/Http/Filter/RepoCreate.php
+++ b/app/Http/Filter/RepoCreate.php
@@ -1,7 +1,6 @@
 <?php
 namespace Intraxia\Gistpen\Http\Filter;
 
-use Intraxia\Jaxion\Contract\Http\Filter as FilterContract;
 use WP_Error;
 
 /**
@@ -10,7 +9,7 @@ use WP_Error;
  * @package Intraxia\Gistpen\Http
  * @subpackage Filters
  */
-class RepoCreate implements FilterContract {
+class RepoCreate extends BaseFilter {
 	/**
 	 * Generates argument rules.
 	 *
@@ -168,15 +167,5 @@ class RepoCreate implements FilterContract {
 			'code'     => $blob['code'],
 			'language' => isset( $blob['language'] ) ? $blob['language'] : null,
 		];
-	}
-
-	/**
-	 * Create validation error to return.
-	 *
-	 * @param  string $message Validation message.
-	 * @return WP_Error        Validation error.
-	 */
-	private function create_error( $message ) {
-		return new WP_Error( 'rest_invalid_param', $message );
 	}
 }

--- a/app/Http/Filter/RepoResource.php
+++ b/app/Http/Filter/RepoResource.php
@@ -1,7 +1,6 @@
 <?php
 namespace Intraxia\Gistpen\Http\Filter;
 
-use Intraxia\Jaxion\Contract\Http\Filter as FilterContract;
 use WP_Error;
 
 /**
@@ -10,7 +9,7 @@ use WP_Error;
  * @package Intraxia\Gistpen\Http
  * @subpackage Filters
  */
-class RepoResource implements FilterContract {
+class RepoResource extends BaseFilter {
 	/**
 	 * Generates argument rules.
 	 *
@@ -23,7 +22,7 @@ class RepoResource implements FilterContract {
 		return array(
 			'id' => array(
 				'required' => true,
-				'type'     => 'int',
+				'type'     => 'integer',
 			),
 		);
 	}


### PR DESCRIPTION
Move the `create_error` method there so we can reuse these
methods across all of the filters.