### PR TITLE
Improve StrictParams handling

### DIFF
--- a/app/Http/StrictParams.php
+++ b/app/Http/StrictParams.php
@@ -52,13 +52,15 @@ class StrictParams implements HasFilters {
 			return $response;
 		}
 
+		// We don't want to validate URL params.
+		$params         = array_merge( $request->get_body_params(), $request->get_query_params() );
 		$invalid_params = [];
 
-		foreach ( $request->get_params() as $key => $value ) {
+		foreach ( $params as $key => $value ) {
 			if ( ! isset( $attributes['args'][ $key ] ) && ! in_array( $key, self::$param_whitelist, true ) ) {
 				$invalid_params[ $key ] = sprintf(
 					/* translators: %s: Request param. */
-					__( 'Param "%s" is not a valid request param.', 'wp-gistpen' ),
+					__( '%s is not a valid request param.', 'wp-gistpen' ),
 					$key
 				);
 			}

--- a/test/Integration/Http/Repo/CreateTest.php
+++ b/test/Integration/Http/Repo/CreateTest.php
@@ -109,7 +109,7 @@ class CreateTest extends TestCase {
 			'data'    => [
 				'status' => 400,
 				'params' => [
-					'extra' => 'Param "extra" is not a valid request param.',
+					'extra' => 'extra is not a valid request param.',
 				],
 			],
 		] );
@@ -135,7 +135,7 @@ class CreateTest extends TestCase {
 				'status' => 400,
 				'params' => [
 					'description' => 'Param "description" must be a string.',
-					'extra'       => 'Param "extra" is not a valid request param.',
+					'extra'       => 'extra is not a valid request param.',
 				],
 			],
 		] );

--- a/test/Integration/Http/Search/BlobsTest.php
+++ b/test/Integration/Http/Search/BlobsTest.php
@@ -38,7 +38,7 @@ class BlobsTest extends TestCase {
 			'data'    => [
 				'status' => 400,
 				'params' => [
-					'invalid' => 'Param "invalid" is not a valid request param.',
+					'invalid' => 'invalid is not a valid request param.',
 				],
 			],
 		] );

--- a/test/Integration/Http/Search/ReposTest.php
+++ b/test/Integration/Http/Search/ReposTest.php
@@ -51,7 +51,7 @@ class ReposTest extends TestCase {
 			'data'    => [
 				'status' => 400,
 				'params' => [
-					'invalid' => 'Param "invalid" is not a valid request param.',
+					'invalid' => 'invalid is not a valid request param.',
 				],
 			],
 		] );

--- a/test/Integration/Http/Site/PatchTest.php
+++ b/test/Integration/Http/Site/PatchTest.php
@@ -22,7 +22,7 @@ class PatchTest extends TestCase {
 			'data'    => [
 				'status' => 400,
 				'params' => [
-					'invalid' => 'Param "invalid" is not a valid request param.',
+					'invalid' => 'invalid is not a valid request param.',
 				],
 			],
 		] );


### PR DESCRIPTION
Only check body & query params, as those are the ones accounted
for in the Filters, and update the message to be consistent with
WordPress core.