### PR TITLE
Make code an empty string by default

### DIFF
--- a/app/Http/Filter/BlobCreate.php
+++ b/app/Http/Filter/BlobCreate.php
@@ -41,7 +41,8 @@ class BlobCreate extends BaseFilter {
 			],
 			'code'     => [
 				'description' => __( 'Code for the blob.', 'wp-gistpen' ),
-				'required'    => true,
+				'required'    => false,
+				'default'     => '',
 				'type'        => 'string',
 			],
 			'language' => [

--- a/client/block/SetEmbed/Creating/__tests__/Creating.spec.tsx
+++ b/client/block/SetEmbed/Creating/__tests__/Creating.spec.tsx
@@ -123,7 +123,6 @@ describe('Creating', () => {
             blobs: [
               {
                 filename: 'filename.js',
-                code: '',
               },
             ],
           }),

--- a/client/block/SetEmbed/Creating/delta.tsx
+++ b/client/block/SetEmbed/Creating/delta.tsx
@@ -25,7 +25,6 @@ export const rootDelta: Delta<RootAction, State> = (action$, state$) => {
           blobs: [
             {
               filename: state.filename,
-              code: '',
             },
           ],
         }),


### PR DESCRIPTION
No reason to require this if an empty string is valid.