### PR TITLE
Fix saving minimal blobs through a repo

### DIFF
--- a/app/Http/Filter/BlobCreate.php
+++ b/app/Http/Filter/BlobCreate.php
@@ -50,9 +50,9 @@ class BlobCreate extends BaseFilter {
 				'type'        => 'string',
 				'enum'        => array_merge(
 					array_keys( $languages['list'] ),
-					array_keys( $languages['aliases'] )
+					array_values( $languages['aliases'] )
 				),
-				'default'     => 'plaintext',
+				'default'     => 'none',
 			],
 		];
 	}

--- a/app/Http/RepoController.php
+++ b/app/Http/RepoController.php
@@ -77,7 +77,24 @@ class RepoController {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function create( WP_REST_Request $request ) {
-		$model = $this->em->create( Repo::class, $request->get_params() );
+		$model = $this->em->create( Repo::class, [
+			'description' => $request->get_param( 'description' ),
+			'status'      => $request->get_param( 'status' ),
+			'password'    => $request->get_param( 'password' ),
+			'sync'        => $request->get_param( 'sync' ),
+			'blobs'       => array_map(function( $blob ) {
+				return [
+					'filename' => $blob['filename'],
+					// @TODO(mAAdhaTTah) this is duplicated with the filter but isn't set correctly when run thru REST API.
+					// shouldn't core set this property by default?
+					'code'     => isset( $blob['code'] ) ? $blob['code'] : '',
+					'language' => [
+						// @TODO(mAAdhaTTah) this is a bad API for the EntityManager.
+						'slug' => isset( $blob['language'] ) ? $blob['language'] : 'none',
+					],
+				];
+			}, $request->get_param( 'blobs' ) ),
+		] );
 
 		if ( is_wp_error( $model ) ) {
 			$model->add_data( array( 'status' => 500 ) );

--- a/test/Integration/Http/Blob/CreateTest.php
+++ b/test/Integration/Http/Blob/CreateTest.php
@@ -99,7 +99,7 @@ class CreateTest extends TestCase {
 			'size'     => $blob->size,
 			'raw_url'  => $blob->raw_url,
 			'edit_url' => $blob->edit_url,
-			'filename' => $this->blob->filename,
+			'filename' => $blob->filename,
 			'code'     => $blob->code,
 			'language' => [
 				'ID'           => $blob->language->ID,

--- a/test/Integration/Http/Repo/CreateTest.php
+++ b/test/Integration/Http/Repo/CreateTest.php
@@ -216,6 +216,7 @@ class CreateTest extends TestCase {
 				[
 					'code'     => $blob->code,
 					'filename' => $blob->filename,
+					'language' => 'js',
 				],
 			],
 		] );
@@ -264,5 +265,68 @@ class CreateTest extends TestCase {
 			'created_at'  => $repo->created_at,
 			'updated_at'  => $repo->updated_at,
 		] );
+		$this->assertEquals( $blob->language->slug, 'js' );
+	}
+
+	public function test_creates_repo_with_one_blob_with_only_filename() {
+		$this->set_role( 'administrator' );
+		$repo    = $this->fm->instance( Repo::class );
+		$blob    = $this->fm->instance( Blob::class );
+		$request = new WP_REST_Request( 'POST', '/intraxia/v1/gistpen/repos' );
+		$request->set_body_params( [
+			'description' => $repo->description,
+			'status'      => $repo->status,
+			'blobs'       => [
+				[
+					'filename' => $blob->filename,
+				],
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertResponseStatus( $response, 201 );
+
+		$repo = $this->app->make( 'database' )
+			->find( Repo::class, $response->get_data()['ID'], [
+				'with' => [
+					'blobs' => [
+						'with' => 'language',
+					],
+				],
+			] );
+		$blob = $repo->blobs->first();
+		$this->assertResponseHeader( $response, 'Location', $repo->rest_url );
+		$this->assertResponseData( $response, [
+			'ID'          => $repo->ID,
+			'description' => $repo->description,
+			'slug'        => $repo->slug,
+			'status'      => $repo->status,
+			'password'    => $repo->password,
+			'gist_id'     => $repo->gist_id,
+			'gist_url'    => $repo->gist_url,
+			'sync'        => $repo->sync,
+			'blobs'       => [
+				[
+					'ID'       => $blob->ID,
+					'size'     => $blob->size,
+					'raw_url'  => $blob->raw_url,
+					'edit_url' => $blob->edit_url,
+					'filename' => $blob->filename,
+					'code'     => '',
+					'language' => [
+						'ID'           => $blob->language->ID,
+						'display_name' => $blob->language->display_name,
+						'slug'         => $blob->language->slug,
+					],
+				],
+			],
+			'rest_url'    => $repo->rest_url,
+			'commits_url' => $repo->commits_url,
+			'html_url'    => $repo->html_url,
+			'created_at'  => $repo->created_at,
+			'updated_at'  => $repo->updated_at,
+		] );
+		$this->assertEquals( $blob->language->slug, 'none' );
 	}
 }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -41,7 +41,8 @@ $_manually_load_plugin = function() use ( $plugin_root ) {
 				'plaintext' => 'PlainText',
 			],
 			'aliases' => [
-				'js' => 'javascript',
+				'js'        => 'javascript',
+				'plaintext' => 'none',
 			],
 		]
 	);


### PR DESCRIPTION
First, `language` wasn't being saved correctly at all. Second,
minimal blobs weren't working correctly because the validation
wasn't working the same way when wrapped. This caught a few
bugs, which are now covered by tests.

Also, this uncovered that `none` wasn't considered a valid
languages because the alias languages were added to the array
incorrectly.