### PR TITLE
Add `globalsChanged` action

### DIFF
--- a/client/globals/actions.ts
+++ b/client/globals/actions.ts
@@ -1,0 +1,7 @@
+import { createAction } from 'typesafe-actions';
+import { GlobalsState } from './state';
+
+export const globalsChanged = createAction(
+  'GLOBALS_CHANGED',
+  resolve => (globals: Partial<GlobalsState>) => resolve(globals),
+);

--- a/client/globals/context.tsx
+++ b/client/globals/context.tsx
@@ -1,7 +1,18 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useEffect } from 'react';
+import { setAutoloaderPath } from '../prism';
 import { GlobalsState, defaultGlobals } from './state';
 
 const GlobalsContext = createContext<GlobalsState>(defaultGlobals);
 
-export const useGlobals = () => useContext(GlobalsContext);
+export const useGlobals = () => {
+  const globals = useContext(GlobalsContext);
+
+  useEffect(() => {
+    setAutoloaderPath(
+      (window.__webpack_public_path__ = globals.url + 'resources/assets/'),
+    );
+  }, [globals.url]);
+
+  return globals;
+};
 export const GlobalsProvider = GlobalsContext.Provider;

--- a/client/globals/index.ts
+++ b/client/globals/index.ts
@@ -1,5 +1,6 @@
 import { GlobalsState } from './state';
 
+export * from './actions';
 export * from './context';
 export * from './state';
 

--- a/client/globals/state.ts
+++ b/client/globals/state.ts
@@ -2,6 +2,7 @@ import { getType } from 'typesafe-actions';
 import { EddyReducer } from 'brookjs';
 import { RootAction } from '../util';
 import { init } from '../actions';
+import { globalsChanged } from './actions';
 
 export type GlobalsState = {
   languages: { [key: string]: string };
@@ -42,6 +43,11 @@ export const globalsReducer: EddyReducer<GlobalsState, RootAction> = (
       return {
         ...state,
         ...action.payload.globals,
+      };
+    case getType(globalsChanged):
+      return {
+        ...state,
+        ...action.payload,
       };
     default:
       return state;

--- a/client/util.ts
+++ b/client/util.ts
@@ -14,5 +14,6 @@ export type RootAction = ActionType<
   typeof import('./actions') &
     typeof import('./search').actions &
     typeof import('./block').actions &
+    typeof import('./globals/actions') &
     typeof import('./snippet/actions')
 >;


### PR DESCRIPTION
This can be used with the Globals context to save the Globals
to the globals `reducer`.