### PR TITLE
Fix assigning to webpack public path

### DIFF
--- a/client/globals/context.tsx
+++ b/client/globals/context.tsx
@@ -9,7 +9,7 @@ export const useGlobals = () => {
 
   useEffect(() => {
     setAutoloaderPath(
-      (window.__webpack_public_path__ = globals.url + 'resources/assets/'),
+      (__webpack_public_path__ = globals.url + 'resources/assets/'),
     );
   }, [globals.url]);
 

--- a/client/setupTests.ts
+++ b/client/setupTests.ts
@@ -27,3 +27,5 @@ beforeEach(() => {
     return;
   }
 };
+
+(global as any).__webpack_public_path__ = '/';


### PR DESCRIPTION
This isn't a global variable. It's provided to the module scope
in Webpack's build. Setting it up as a global variable in Jest
allows the tests to continue to pass.