### PR TITLE
Integrate dependency extraction plugin

### DIFF
--- a/.beaverrc.js
+++ b/.beaverrc.js
@@ -4,6 +4,7 @@ import StyleLintPlugin from 'stylelint-webpack-plugin';
 import WebpackNotifierPlugin from 'webpack-notifier';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import DependencyExtractionWebpackPlugin from '@wordpress/dependency-extraction-webpack-plugin';
 
 const isProd = state => state.env === 'production';
 
@@ -155,6 +156,13 @@ export const webpack = {
       }),
     );
     config.plugins.push(new PrismLanguageGenerationPlugin());
+    config.plugins.push(
+      new DependencyExtractionWebpackPlugin({
+        outputFormat: 'json',
+        combineAssets: true,
+        combinedOutputFile: `wp-assets${isProd(state) ? '.min' : ''}.json`,
+      }),
+    );
 
     if (isProd(state)) {
       config.plugins[0].opts.fileName = 'asset-manifest.min.json';
@@ -176,16 +184,6 @@ export const webpack = {
         }),
       );
     }
-
-    config.externals = {
-      react: 'React',
-      'react-dom': 'ReactDOM',
-      '@wordpress/blocks': 'wp.blocks',
-      '@wordpress/components': 'wp.components',
-      '@wordpress/compose': 'wp.compose',
-      '@wordpress/element': 'wp.element',
-      '@wordpress/i18n': 'wp.i18n',
-    };
 
     return config;
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/wordpress__element": "^2.4.0",
     "@types/wordpress__i18n": "^3.11.0",
     "@wordpress/components": "^9.6.0",
+    "@wordpress/dependency-extraction-webpack-plugin": "^2.6.0",
     "@wordpress/e2e-test-utils": "^4.7.0",
     "@wordpress/scripts": "^9.0.0",
     "babel-plugin-prismjs": "^2.0.1",

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -61,6 +61,16 @@ $_manually_load_plugin = function() use ( $plugin_root ) {
 		$dummy_asset_manifest
 	);
 
+	create_if_missing(
+		$plugin_root . '/resources/assets/wp-assets.json',
+		[]
+	);
+
+	create_if_missing(
+		$plugin_root . '/resources/assets/wp-assets.min.json',
+		[]
+	);
+
 	require $plugin_root . '/wp-gistpen.php';
 
 	container()->get( Lifecycle::class )->activate();


### PR DESCRIPTION
This makes it easier to manage each entrypoint's dependencies
without over-adding dependencies not used.

Fixes #700.