### PR TITLE
Expand WP module

### DIFF
--- a/client/actions/index.ts
+++ b/client/actions/index.ts
@@ -3,7 +3,6 @@ export * from './ajax';
 export * from './author';
 export * from './commits';
 export * from './editor';
-export * from './form';
 export * from './highlighting';
 export * from './init';
 export * from './jobs';

--- a/client/block/SetEmbed/Creating/View.tsx
+++ b/client/block/SetEmbed/Creating/View.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { ofType } from 'brookjs';
-import { TextControl, Button, ErrorNotice } from '../../../wp';
+import {
+  TextControl,
+  Button,
+  ErrorNotice,
+  actions as wpActions,
+} from '../../../wp';
 import { Choosing } from '../../../search';
 import CreateOrChoose from '../CreateOrChoose';
-import { click, change } from '../../../actions';
 import {
   createRepoClick,
   createDescriptionChange,
@@ -27,7 +31,7 @@ const FilenameInput: React.FC<{ disabled: boolean; value: string }> = ({
       value={value}
       preplug={a$ =>
         a$
-          .thru(ofType(change))
+          .thru(ofType(wpActions.change))
           .map(action => createFilenameChange(action.payload.value))
       }
     />
@@ -70,7 +74,7 @@ const CreateNew: React.FC<NewRepoState> = ({
         value={description}
         preplug={a$ =>
           a$
-            .thru(ofType(change))
+            .thru(ofType(wpActions.change))
             .map(action => createDescriptionChange(action.payload.value))
         }
       />
@@ -78,7 +82,7 @@ const CreateNew: React.FC<NewRepoState> = ({
       <Button
         isPrimary
         disabled={!description || saving}
-        preplug={a$ => a$.thru(ofType(click)).map(createRepoClick)}
+        preplug={a$ => a$.thru(ofType(wpActions.click)).map(createRepoClick)}
       >
         Create repo
       </Button>

--- a/client/search/View.tsx
+++ b/client/search/View.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { ofType, Maybe } from 'brookjs';
-import { TextControl, ErrorNotice, WarningNotice } from '../wp';
-import { change } from '../actions';
+import {
+  TextControl,
+  ErrorNotice,
+  WarningNotice,
+  actions as wpActions,
+} from '../wp';
 import {
   searchResultSelectClick,
   searchResultSelectionChange,
@@ -43,7 +47,9 @@ export const View: React.FC<{
           value={term}
           data-testid="search-input"
           preplug={e$ =>
-            e$.thru(ofType(change)).map(a => searchInput(a.payload.value))
+            e$
+              .thru(ofType(wpActions.change))
+              .map(a => searchInput(a.payload.value))
           }
         />
       </div>

--- a/client/wp/Button.tsx
+++ b/client/wp/Button.tsx
@@ -1,7 +1,7 @@
 import { toJunction } from 'brookjs';
 import { Button } from '@wordpress/components';
 import { Stream } from 'kefir';
-import { click } from '../actions';
+import { click } from './actions';
 
 const events = {
   onClick: (e$: Stream<void, never>) => e$.map(click),

--- a/client/wp/CheckboxControl.tsx
+++ b/client/wp/CheckboxControl.tsx
@@ -1,0 +1,10 @@
+import { toJunction } from 'brookjs';
+import { CheckboxControl } from '@wordpress/components';
+import { Stream } from 'kefir';
+import { checked } from './actions';
+
+const events = {
+  onChange: (e$: Stream<boolean, never>) => e$.map(checked),
+};
+
+export default toJunction(events)(CheckboxControl);

--- a/client/wp/SelectControl.tsx
+++ b/client/wp/SelectControl.tsx
@@ -1,5 +1,5 @@
 import { toJunction } from 'brookjs';
-import { TextControl } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { Stream } from 'kefir';
 import { change } from './actions';
 
@@ -7,4 +7,4 @@ const events = {
   onChange: (e$: Stream<string, never>) => e$.map(change),
 };
 
-export default toJunction(events)(TextControl);
+export default toJunction(events)(SelectControl);

--- a/client/wp/actions.ts
+++ b/client/wp/actions.ts
@@ -4,4 +4,9 @@ export const change = createAction('CHANGE', resolve => (value: string) =>
   resolve({ value }),
 );
 
+export const checked = createAction(
+  'CHECKED',
+  resolve => (isChecked: boolean) => resolve({ isChecked }),
+);
+
 export const click = createAction('CLICK');

--- a/client/wp/index.ts
+++ b/client/wp/index.ts
@@ -1,4 +1,9 @@
+import * as actions from './actions';
+
+export { actions };
 export { default as Button } from './Button';
 export * from './notices';
 export * from './Shortcode';
+export { default as SelectControl } from './SelectControl';
 export { default as TextControl } from './TextControl';
+export { default as CheckboxControl } from './CheckboxControl';


### PR DESCRIPTION
Move the form actions into the WP module where the
WP form elements live. Wrap some additional controls
in `toJunction` so we can use them.