### PR TITLE
Fix language none

### DIFF
--- a/.beaverrc.js
+++ b/.beaverrc.js
@@ -55,10 +55,9 @@ class PrismLanguageGenerationPlugin {
   languagesToDest(languages) {
     const dest = {
       list: {
-        plaintext: 'PlainText',
+        none: 'PlainText',
       },
       aliases: {
-        plaintext: 'none',
         jinja2: 'django',
       },
     };


### PR DESCRIPTION
Make sure we take aliases into account with `prismSlug`.

Fixes #1010.