### PR TITLE
Eliminate language `none`

### DIFF
--- a/.beaverrc.js
+++ b/.beaverrc.js
@@ -58,7 +58,6 @@ class PrismLanguageGenerationPlugin {
         plaintext: 'PlainText',
       },
       aliases: {
-        plaintext: 'none',
         jinja2: 'django',
       },
     };

--- a/app/Database/Repository/AbstractRepository.php
+++ b/app/Database/Repository/AbstractRepository.php
@@ -84,7 +84,7 @@ abstract class AbstractRepository implements Repository {
 						$term = array_pop( $terms );
 					} else {
 						$term       = new WP_Term( new stdClass() );
-						$term->slug = 'none';
+						$term->slug = 'plaintext';
 					}
 
 					$value = new Language( array( Model::OBJECT_KEY => $term ) );

--- a/app/Database/Repository/WordPressPost.php
+++ b/app/Database/Repository/WordPressPost.php
@@ -142,14 +142,26 @@ class WordPressPost extends AbstractRepository {
 		}
 
 		// Whitelist params send to WP_Query.
-		foreach ( array( 'post_status', 'order', 'orderby', 'offset', 's', 'limit' ) as $param ) {
+		foreach ( array( 'post_status', 'order', 'orderby', 'offset', 's', 'limit', 'language' ) as $param ) {
 			if ( isset( $params[ $param ] ) ) {
+				$value = $params[ $param ];
+
 				switch ( $param ) {
+					case 'language':
+						// TODO abstract related by term query
+						$query_args['tax_query'] = [
+							[
+								'taxonomy' => Language::get_taxonomy(),
+								'field'    => 'slug',
+								'terms'    => $value,
+							],
+						];
+						break;
 					case 'limit':
-						$query_args['posts_per_page'] = $params[ $param ];
+						$query_args['posts_per_page'] = $value;
 						break;
 					default:
-						$query_args[ $param ] = $params[ $param ];
+						$query_args[ $param ] = $value;
 						break;
 				}
 			}

--- a/app/Database/Repository/WordPressTerm.php
+++ b/app/Database/Repository/WordPressTerm.php
@@ -28,7 +28,7 @@ class WordPressTerm extends AbstractRepository {
 		$term     = get_term( $id, $taxonomy );
 
 		if ( ! $term ) {
-			$term = new WP_Error( 'db_error', __( 'Error getting term', 'wp-gistpen' ) );
+			$term = new WP_Error( 'not_found', __( 'Term not found', 'wp-gistpen' ) );
 		}
 
 		if ( is_wp_error( $term ) ) {

--- a/app/Http/Filter/BlobCreate.php
+++ b/app/Http/Filter/BlobCreate.php
@@ -52,7 +52,7 @@ class BlobCreate extends BaseFilter {
 					array_keys( $languages['list'] ),
 					array_values( $languages['aliases'] )
 				),
-				'default'     => 'none',
+				'default'     => 'plaintext',
 			],
 		];
 	}

--- a/app/Http/RepoController.php
+++ b/app/Http/RepoController.php
@@ -92,7 +92,7 @@ class RepoController {
 					'code'     => isset( $blob['code'] ) ? $blob['code'] : '',
 					'language' => [
 						// @TODO(mAAdhaTTah) this is a bad API for the EntityManager.
-						'slug' => isset( $blob['language'] ) ? $blob['language'] : 'none',
+						'slug' => isset( $blob['language'] ) ? $blob['language'] : 'plaintext',
 					],
 				];
 			}, $request->get_param( 'blobs' ) ),

--- a/client/block/EditEmbed/index.tsx
+++ b/client/block/EditEmbed/index.tsx
@@ -78,7 +78,7 @@ const defaultEmbedState: EmbedState = {
   blob: null,
   filename: '',
   code: '',
-  language: 'none',
+  language: 'plaintext',
   theme: 'default',
   width: 2,
   tabs: false,

--- a/client/prism/index.ts
+++ b/client/prism/index.ts
@@ -3,7 +3,7 @@ import langs from '../../resources/languages.json';
 
 // @ts-ignore
 Prism.manual = true;
-Prism.languages.none = {};
+Prism.languages.plaintext = {};
 
 type Theme = {
   use(): void;

--- a/test/Integration/Http/Repo/CreateTest.php
+++ b/test/Integration/Http/Repo/CreateTest.php
@@ -327,6 +327,6 @@ class CreateTest extends TestCase {
 			'created_at'  => $repo->created_at,
 			'updated_at'  => $repo->updated_at,
 		] );
-		$this->assertEquals( $blob->language->slug, 'none' );
+		$this->assertEquals( $blob->language->slug, 'plaintext' );
 	}
 }

--- a/test/Unit/Listener/MigrationTest.php
+++ b/test/Unit/Listener/MigrationTest.php
@@ -3,6 +3,9 @@ namespace Intraxia\Jaxion\Test\Unit\Listener;
 
 use Intraxia\Gistpen\Listener\Migration;
 use Intraxia\Gistpen\Test\Unit\TestCase;
+use Intraxia\Gistpen\Model\Repo;
+use Intraxia\Gistpen\Model\Blob;
+use Intraxia\Gistpen\Model\Language;
 use Mockery\Mock;
 
 class MigrationTest extends TestCase {
@@ -50,5 +53,38 @@ class MigrationTest extends TestCase {
 			array( 'gist' => array( 'token' => $old_opts['_wpgp_gist_token'] ) ),
 			get_option( $slug . '_priv' )
 		);
+	}
+
+	public function test_should_update_to_2_0_0() {
+		$repo      = $this->fm->create( Repo::class );
+		$none      = $this->fm->create( Language::class, [ 'slug' => 'none' ] );
+		$java      = $this->fm->create( Language::class, [ 'slug' => 'java' ] );
+		$none_blob = $this->fm->create( Blob::class, [
+			'repo_id'  => $repo->ID,
+			'language' => $none,
+		] );
+		$java_blob = $this->fm->create( Blob::class, [
+			'repo_id'  => $repo->ID,
+			'language' => $java,
+		] );
+		update_option( 'wp_gistpen_version', '1.0.0' );
+
+		$this->migration->run();
+
+		$em        = $this->app->get( 'database' );
+		$none_blob = $em->find( Blob::class, $none_blob->ID, [
+			'with' => 'language',
+		] );
+		$java_blob = $em->find( Blob::class, $java_blob->ID, [
+			'with' => 'language',
+		] );
+
+		$this->assertEquals( 'plaintext', $none_blob->language->slug );
+		$this->assertEquals( 'java', $java_blob->language->slug );
+
+		$none = $em->find( Language::class, $none->ID );
+
+		$this->assertWPError( $none );
+		$this->assertEquals( 'not_found', $none->get_error_code() );
 	}
 }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -41,8 +41,7 @@ $_manually_load_plugin = function() use ( $plugin_root ) {
 				'plaintext' => 'PlainText',
 			],
 			'aliases' => [
-				'js'        => 'javascript',
-				'plaintext' => 'none',
+				'js' => 'javascript',
 			],
 		]
 	);


### PR DESCRIPTION
Move `none` into the base list instead of as an alias, harmonizing the
language used in the BE with prism's `none`.

Fixes #1010.