### PR TITLE
Sync user settings in the sidebar w/ API

### DIFF
--- a/client/RootAction.ts
+++ b/client/RootAction.ts
@@ -7,5 +7,6 @@ export type RootAction = ActionType<
     typeof import('./globals/actions') &
     typeof import('./snippet/actions') &
     typeof import('./editor/actions') &
-    typeof import('./settings/actions')
+    typeof import('./settings/actions') &
+    typeof import('./me/actions')
 >;

--- a/client/actions/editor.ts
+++ b/client/actions/editor.ts
@@ -1,5 +1,5 @@
 import { createAction } from 'typesafe-actions';
-import { Toggle } from '../snippet';
+import { Toggle } from '../api';
 import { Cursor } from '../editor/types';
 
 export type EditorValue = {

--- a/client/api/Toggle.ts
+++ b/client/api/Toggle.ts
@@ -1,0 +1,5 @@
+import * as t from 'io-ts';
+
+export const Toggle = t.union([t.literal('on'), t.literal('off')]);
+
+export type Toggle = t.TypeOf<typeof Toggle>;

--- a/client/api/index.ts
+++ b/client/api/index.ts
@@ -2,6 +2,8 @@ import * as t from 'io-ts';
 import { NetworkError, ObsResponse } from 'kefir-ajax';
 import Kefir, { Observable } from 'kefir';
 
+export * from './Toggle';
+
 export const validationErrorsToString = (errs: t.Errors) =>
   `API response validation failed:\n\n${errs
     .map(

--- a/client/components/EditPage/Controls.tsx
+++ b/client/components/EditPage/Controls.tsx
@@ -12,7 +12,7 @@ import {
   editorUpdateClick,
   editorAddClick,
 } from '../../actions';
-import { Toggle } from '../../snippet';
+import { Toggle } from '../../api';
 import { editorWidthChange } from '../../editor/actions';
 
 const mapCheckedToString = (e: React.ChangeEvent<HTMLInputElement>): Toggle =>

--- a/client/components/EditPage/index.tsx
+++ b/client/components/EditPage/index.tsx
@@ -1,8 +1,7 @@
 import './index.scss';
 import React, { useRef, useEffect, useMemo } from 'react';
 import Editor from '../Editor';
-import { AjaxError } from '../../api';
-import { Toggle } from '../../snippet';
+import { AjaxError, Toggle } from '../../api';
 import { Cursor } from '../../editor/types';
 import Description from './Description';
 import Controls from './Controls';

--- a/client/components/Editor/Code.tsx
+++ b/client/components/Editor/Code.tsx
@@ -14,7 +14,7 @@ import {
 import { selectSelectionStart, selectSelectionEnd } from '../../selectors';
 import { prismSlug, setTheme, togglePlugin } from '../../prism';
 import { RootAction } from '../../RootAction';
-import { Toggle } from '../../snippet';
+import { Toggle } from '../../api';
 import { Cursor } from '../../editor/types';
 import { isSpecialEvent, languageIsEqual, editorOptionsIsEqual } from './util';
 import findOffset from './findOffset';

--- a/client/components/Editor/types.ts
+++ b/client/components/Editor/types.ts
@@ -1,4 +1,4 @@
-import { Toggle } from '../../snippet';
+import { Toggle } from '../../api';
 import { Cursor } from '../../editor/types';
 
 export type Props = {

--- a/client/me/actions.ts
+++ b/client/me/actions.ts
@@ -1,0 +1,16 @@
+import { DeepPartial } from 'redux';
+import { createAsyncAction } from 'typesafe-actions';
+import { AjaxError } from '../api';
+import { ApiMe } from './types';
+
+export const fetchMe = createAsyncAction(
+  'FETCH_ME_REQUESTED',
+  'FETCH_ME_SUCCEEDED',
+  'FETCH_ME_FAILED',
+)<void, ApiMe, AjaxError>();
+
+export const saveMe = createAsyncAction(
+  'SAVE_ME_REQUESTED',
+  'SAVE_ME_SUCCEEDED',
+  'SAVE_ME_FAILED',
+)<DeepPartial<ApiMe>, ApiMe, AjaxError>();

--- a/client/me/index.ts
+++ b/client/me/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './actions';

--- a/client/me/types.ts
+++ b/client/me/types.ts
@@ -1,0 +1,13 @@
+import * as t from 'io-ts';
+import { Toggle } from '../api';
+
+export const ApiMe = t.type({
+  editor: t.type({
+    indent_width: t.string,
+    invisibles_enabled: Toggle,
+    tabs_enabled: Toggle,
+    theme: t.string,
+  }),
+});
+
+export type ApiMe = t.TypeOf<typeof ApiMe>;

--- a/client/reducers/editor.ts
+++ b/client/reducers/editor.ts
@@ -22,8 +22,7 @@ import {
   ajaxFailed,
 } from '../actions';
 import { RootAction } from '../RootAction';
-import { AjaxError } from '../api';
-import { Toggle } from '../snippet';
+import { AjaxError, Toggle } from '../api';
 import { Cursor } from '../editor/types';
 import { editorWidthChange } from '../editor/actions';
 

--- a/client/search/delta.tsx
+++ b/client/search/delta.tsx
@@ -3,8 +3,7 @@ import Kefir, { Observable } from 'kefir';
 import * as t from 'io-ts';
 import { ajax$ } from 'kefir-ajax';
 import { RootAction } from '../RootAction';
-import { ValidationError, JsonError } from '../api';
-import { Toggle } from '../snippet';
+import { ValidationError, JsonError, Toggle } from '../api';
 import { search } from './actions';
 import { Collection, RepoCollection, BlobCollection } from './state';
 

--- a/client/snippet/types.ts
+++ b/client/snippet/types.ts
@@ -1,8 +1,5 @@
 import * as t from 'io-ts';
-
-export const Toggle = t.union([t.literal('on'), t.literal('off')]);
-
-export type Toggle = t.TypeOf<typeof Toggle>;
+import { Toggle } from '../api';
 
 export const ApiLanguage = t.type({
   ID: t.union([t.number, t.null]),


### PR DESCRIPTION
Saves the user editor settings to the backend so they get persisted
across sessions.

Fixes #964.