### PR TITLE
Add line numbers to Gutenberg block

### DIFF
--- a/client/block/EditEmbed/index.tsx
+++ b/client/block/EditEmbed/index.tsx
@@ -375,6 +375,10 @@ const EditEmbed: React.FC<{ blobId: number; repoId: number }> = ({
     togglePlugin('show-invisibles', state.embed.showInvisibles);
   }, [state.embed.showInvisibles]);
 
+  useEffect(() => {
+    togglePlugin('line-numbers', state.embed.lineNumbers);
+  }, [state.embed.lineNumbers]);
+
   const themes = useMemo(
     () =>
       Object.entries(state.globals.themes).map(([value, label]) => ({
@@ -465,6 +469,7 @@ const EditEmbed: React.FC<{ blobId: number; repoId: number }> = ({
             Prism={Prism}
             language={prismSlug(state.embed.language)}
             initialCode={state.embed.blob.code}
+            lineNumbers={state.embed.lineNumbers}
             width={state.embed.width}
             tabs={state.embed.tabs}
           />

--- a/client/editor/Code.tsx
+++ b/client/editor/Code.tsx
@@ -25,6 +25,7 @@ type Props = {
   code: string;
   cursor: Cursor;
   language: string;
+  lineNumbers?: boolean;
   onBlur: (e: React.FocusEvent<HTMLElement>) => void;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
   onFocus: (e: React.FocusEvent<HTMLElement>) => void;
@@ -135,11 +136,20 @@ const codeStyles: React.CSSProperties = {
 };
 
 const Code: React.ForwardRefRenderFunction<HTMLPreElement, Props> = (
-  { language, onBlur, onClick, onFocus, onInput, onKeyUp, onKeyDown },
+  {
+    language,
+    lineNumbers = false,
+    onBlur,
+    onClick,
+    onFocus,
+    onInput,
+    onKeyUp,
+    onKeyDown,
+  },
   ref,
 ) => (
   <pre
-    className={`language-${language} line-numbers`}
+    className={`language-${language} ${lineNumbers ? `line-numbers` : ''}`}
     spellCheck={false}
     ref={ref}
   >

--- a/client/editor/Code.tsx
+++ b/client/editor/Code.tsx
@@ -138,7 +138,7 @@ const codeStyles: React.CSSProperties = {
 const Code: React.ForwardRefRenderFunction<HTMLPreElement, Props> = (
   {
     language,
-    lineNumbers = false,
+    lineNumbers = true,
     onBlur,
     onClick,
     onFocus,

--- a/client/editor/Editor.tsx
+++ b/client/editor/Editor.tsx
@@ -29,7 +29,7 @@ const Editor: React.FC<{
   language,
   tabs,
   width,
-  lineNumbers = false,
+  lineNumbers = true,
   initialCode = initialState.code,
   onStateChange,
 }) => {

--- a/client/editor/Editor.tsx
+++ b/client/editor/Editor.tsx
@@ -19,6 +19,7 @@ const Editor: React.FC<{
   language: string;
   tabs?: boolean;
   width?: number;
+  lineNumbers?: boolean;
   initialCode?: string;
   onStateChange: (action: ActionType<typeof editorStateChange>) => void;
 }> = ({
@@ -28,6 +29,7 @@ const Editor: React.FC<{
   language,
   tabs,
   width,
+  lineNumbers = false,
   initialCode = initialState.code,
   onStateChange,
 }) => {
@@ -59,6 +61,7 @@ const Editor: React.FC<{
         <Code
           Prism={Prism}
           language={language}
+          lineNumbers={lineNumbers}
           code={state.code}
           cursor={state.cursor}
         />


### PR DESCRIPTION
Add class name to `Code` piece of the element + inject via `Prism` in
the `EditEmbed`.

Fixes #1011.