### PR TITLE
Add listener to save commit on blob update

### DIFF
--- a/app/Database/Repository/AbstractRepository.php
+++ b/app/Database/Repository/AbstractRepository.php
@@ -5,6 +5,7 @@ namespace Intraxia\Gistpen\Database\Repository;
 use Intraxia\Gistpen\Contract\Repository;
 use Intraxia\Gistpen\Model\Blob;
 use Intraxia\Gistpen\Model\Language;
+use Intraxia\Gistpen\Model\Commit;
 use Intraxia\Gistpen\Model\State;
 use Intraxia\Jaxion\Contract\Axolotl\EntityManager;
 use Intraxia\Jaxion\Axolotl\Collection;
@@ -100,10 +101,20 @@ abstract class AbstractRepository implements Repository {
 						}
 					}
 					break;
+				case 'commits':
+					$value = $this->em->find_by( Commit::class, array_merge( $params, array(
+						'repo_id'     => $model->get_primary_id(),
+						'post_status' => 'any',
+						'order'       => 'ASC',
+						'orderby'     => 'date',
+					) ) );
+					break;
 			}
 
 			if ( null !== $value ) {
+				$model->unguard();
 				$model->set_attribute( $key, $value );
+				$model->reguard();
 			}
 		}
 

--- a/app/Database/Repository/WordPressPost.php
+++ b/app/Database/Repository/WordPressPost.php
@@ -254,7 +254,7 @@ class WordPressPost extends AbstractRepository {
 				$blob_data['repo_id'] = $model->get_primary_id();
 				$blob_data['status']  = $model->get_attribute( 'status' );
 
-				$blob = $this->em->create( Blob::class, $blob_data, array(
+				$blob = $this->create( Blob::class, $blob_data, array(
 					'unguarded' => true,
 				) );
 
@@ -338,7 +338,7 @@ class WordPressPost extends AbstractRepository {
 				$blob->status  = $model->get_attribute( 'status' );
 				$blob->reguard();
 
-				$this->em->persist( $blob );
+				$this->persist( $blob );
 			}
 
 			foreach ( $deleted_blobs as $deleted_blob ) {
@@ -389,7 +389,7 @@ class WordPressPost extends AbstractRepository {
 			$states = new Collection( State::class );
 
 			foreach ( $model->states as $state ) {
-				$state = $this->em->persist( $state );
+				$state = $this->persist( $state );
 
 				if ( ! is_wp_error( $state ) ) {
 					$states = $states->add( $state );

--- a/app/Listener/Database.php
+++ b/app/Listener/Database.php
@@ -36,7 +36,7 @@ class Database implements HasActions {
 	 *
 	 * @param Repo $repo
 	 */
-	public function add_commit( Repo $repo ) {
+	public function add_repo_commit( Repo $repo ) {
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
 			'with'    => array(
@@ -115,6 +115,21 @@ class Database implements HasActions {
 		} )->to_array();
 
 		$this->em->persist( $new_commit );
+	}
+
+	/**
+	 * Checks if the Repo has changed and creates a new commit if it has.
+	 *
+	 * @param Blob $blob
+	 */
+	public function add_blob_commit( Blob $blob ) {
+		$this->add_repo_commit( $this->em->find( Repo::class, $blob->repo_id, [
+			'with' => [
+				'blobs' => [
+					'with' => 'language',
+				],
+			],
+		] ) );
 	}
 
 	/**
@@ -206,11 +221,19 @@ class Database implements HasActions {
 		return array(
 			array(
 				'hook'   => 'wpgp.create.repo',
-				'method' => 'add_commit',
+				'method' => 'add_repo_commit',
 			),
 			array(
 				'hook'   => 'wpgp.persist.repo',
-				'method' => 'add_commit',
+				'method' => 'add_repo_commit',
+			),
+			array(
+				'hook'   => 'wpgp.create.blob',
+				'method' => 'add_blob_commit',
+			),
+			array(
+				'hook'   => 'wpgp.persist.blob',
+				'method' => 'add_blob_commit',
 			),
 			array(
 				'hook'     => 'post_updated',

--- a/app/Model/Repo.php
+++ b/app/Model/Repo.php
@@ -68,6 +68,7 @@ class Repo extends Model implements UsesWordPressPost {
 		'gist_id',
 		'created_at',
 		'updated_at',
+		'commits',
 	);
 
 	/**

--- a/test/Integration/Http/Blob/CreateTest.php
+++ b/test/Integration/Http/Blob/CreateTest.php
@@ -83,9 +83,14 @@ class CreateTest extends TestCase {
 		$repo = $this->app->make( 'database' )
 			->find( Repo::class, $this->repo->ID, [
 				'with' => [
-					'blobs' => [
+					'blobs'   => [
 						'with' => [
 							'language' => [],
+						],
+					],
+					'commits' => [
+						'with' => [
+							'states' => [],
 						],
 					],
 				],
@@ -108,6 +113,7 @@ class CreateTest extends TestCase {
 			],
 		] );
 		$this->assertSame( $blob->filename, $this->blob->filename );
+		$this->assertCount( 2, $repo->commits );
 	}
 
 	public function test_saves_blob_with_filename_code_and_language() {

--- a/test/Unit/Listener/DatabaseTest.php
+++ b/test/Unit/Listener/DatabaseTest.php
@@ -35,7 +35,6 @@ class DatabaseTest extends TestCase {
 		parent::setUp();
 
 		$this->em       = $this->app->make( EntityManager::class );
-		$this->database = $this->app->make( Database::class );
 	}
 
 	public function test_should_save_when_no_commits_saved() {
@@ -57,7 +56,7 @@ class DatabaseTest extends TestCase {
 			),
 		) );
 
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -104,7 +103,7 @@ class DatabaseTest extends TestCase {
 			'with'    => 'states',
 		) );
 
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -128,7 +127,7 @@ class DatabaseTest extends TestCase {
 
 		$repo->description = 'New Description';
 
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -177,9 +176,9 @@ class DatabaseTest extends TestCase {
 		$blob->repo_id  = $repo->ID;
 		$blob->reguard();
 
-		$repo->blobs = $repo->blobs->add( $blob = $this->em->persist( $blob ) );
+		$repo->blobs = $repo->blobs->add( $blob );
 
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -234,7 +233,7 @@ class DatabaseTest extends TestCase {
 
 		$repo->blobs = $repo->blobs->remove_at( 2 );
 
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -289,9 +288,9 @@ class DatabaseTest extends TestCase {
 		/** @var Blob $removed_blob */
 		$removed_blob = $repo->blobs->at( 2 );
 
-		$repo->blobs = $repo->blobs->remove_at( 2 )->add( $blob = $this->em->persist( $blob ) );
+		$repo->blobs = $repo->blobs->remove_at( 2 )->add( $blob );
 
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -349,9 +348,7 @@ class DatabaseTest extends TestCase {
 
 		$blob->code = 'some new php code';
 
-		$this->em->persist( $blob );
-
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -406,9 +403,7 @@ class DatabaseTest extends TestCase {
 
 		$blob->filename = 'new-slug.php';
 
-		$this->em->persist( $blob );
-
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,
@@ -467,7 +462,7 @@ class DatabaseTest extends TestCase {
 			->find_by( Language::class, array( 'slug' => 'js' ) )
 			->first();
 
-		$this->database->add_commit( $repo );
+		$this->em->persist( $repo );
 
 		$commits = $this->em->find_by( Commit::class, array(
 			'repo_id' => $repo->ID,


### PR DESCRIPTION
Update the usage of `$this->em->{persist,create}` to
`$this->{persist,create}` to ensure the action isn't dispatched when
saving relations, so we can hook into the blob save action to persist
the commit.

Fixes #866.